### PR TITLE
gorequest wasn't sending the request for validation

### DIFF
--- a/appstore/validator.go
+++ b/appstore/validator.go
@@ -99,9 +99,15 @@ func NewWithConfig(config Config) Client {
 // Verify sends receipts and gets validation result
 func (c *Client) Verify(req *IAPRequest) (IAPResponse, error) {
 	result := IAPResponse{}
+	obj, err_json := json.Marshal(req)
+	if err_json != nil {
+		return result, fmt.Errorf("%v", err_json)
+	}
+
 	res, body, errs := gorequest.New().
 		Post(c.URL).
-		Send(req).
+		Type("json").
+		SendString(string(obj)).
 		Timeout(c.TimeOut).
 		End()
 


### PR DESCRIPTION
In the gorequest Send method, there is a switch that checks the type of the parameter (https://github.com/parnurzeal/gorequest/blob/master/main.go#L341). In this particular case, the type of *IAPRequest is "ptr" which results in gorequest's switch to go the default case which is empty. The request was made with an empty body.
